### PR TITLE
A few additions as per IRC discussion...

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for {{ $dist->name }}
           - Add Data::Printer (per Sawyer X)
           - Add Devel::Dwarn (per mst)
           - Add Pinto (per Sawyer X)
+          - Add App::FatPacker (per perigrin)
 
 0.36      2014-03-08
           - fix pod markup error in main Task::Kensho distribution

--- a/modules.yml
+++ b/modules.yml
@@ -146,6 +146,7 @@ Task::Kensho::Toolchain:
     long_description: =for stopwords Bundler
     components:
         App::cpanminus: Get, unpack, build and install modules from CPAN
+        App::FatPacker: Pack your dependencies onto your script file
         App::perlbrew: Manage perl installations in your $HOME
         Carton: Perl module dependency manager (aka Bundler for Perl)
         CPAN::Mini: Create a minimal mirror of CPAN


### PR DESCRIPTION
11:31 < ranguard> https://metacpan.org/pod/Data::Printer <- worth adding to Kensho?
11:31 < mst> yes
11:32 < mst> also Devel::Confess as a better Carp::Always
11:32  \* ranguard will make a pull request
11:32 < mst> hrm, do we not have a debugging section?
11:32 < mst> I'd've expected Devel::Dwarn to be in there as well
11:32 < ranguard> https://metacpan.org/pod/Task::Kensho::ModuleDev
11:33 < mst> ah. I'd regard 'module building/linting stuff' as separate from straight debugging, hence not
             realising that
11:34  \* ranguard looks at the fuzzy line and decides someone else can make a decision
11:35 < mst> yeah, for the moment just get the extra modules into the current section
11:35 < mst> we can discuss splitting it separately
11:36 < ranguard> https://metacpan.org/pod/Sereal ?
11:36  \* ranguard is just listening to Sawyer's NA talk about what we should be recommending
11:37 < mst> yes, though not sure which section you'd put that in
11:38 < ranguard> yea, hmm.. will look.. last one
11:38 < ranguard> Pinto?
11:40 < mst> is interesting but hasn't got the sort of wide usage that dictates it as a recommended solution
11:40 < mst> we don't have minicpan in there either AFAIK
11:41 < ranguard> It is - under Toolchain
11:41 < ranguard> CPAN::Mini
11:41 < mst> mm. then, yes, Pinto should also be there.
15:57 < ether> we definitely need a dev tools section
15:57 < ether> but toolchain is different from things like debugger tools
15:58 < ether> e.g. App::FatPacker, local::lib in the first, Devel::Confess in the second.
15:58 < mst> right
16:08 < ether> also Devel::TraceUse, Devel::Gladiator, Test::RequiresInternet, Test::DescribeMe, Test::Is
16:51 < perigrin> Actually splitting Building / Linting from Debugging seems fine
16:51  \* perigrin hadn't gotten to where ether chimed in yet
16:52 < perigrin> Carton / CPAN::Mini / Pinto should all be in a toolchain
16:52 < perigrin> (along with App::FatPacker and local::lib)
