### PR TITLE
s/HTML::BrowserDetect/HTTP::BrowserDetect/

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -187,7 +187,7 @@ Task::Kensho::WebDev:
         Dancer2: the new generation of Dancer, a lightweight yet powerful web application framework
         Mojolicious: Real-time web framework
         Template: (Template::Toolkit) Template Processing System
-        HTML::BrowserDetect: Determine Web browser, version, and platform from an HTTP user agent string
+        HTTP::BrowserDetect: Determine Web browser, version, and platform from an HTTP user agent string
         HTML::FormHandler: HTML forms using Moose
         CGI::FormBuilder::Source::Perl: Build CGI::FormBuilder configs from Perl syntax files.
         XML::RSS: Creates and updates RSS files


### PR DESCRIPTION
I think this is the correct change.  I cannot find HTML::BrowserDetect
on CPAN and the description for this module matches that of
HTTP::BrowserDetect word for word.