### PR TITLE
modules.yml: Make long descriptions more readable

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -1,7 +1,9 @@
 ---
 # this is not in yml to make perigrin cry, but just because ether speaks this
 # more natively than INI. change to another format as desired!
-# To parse: perl -MYAML::Any=LoadFile -MData::Dumper -wle'print Dumper(LoadFile("modules.yml"))'
+# To parse:
+# perl -MYAML::Any=LoadFile -MData::Dumper -wle'print Dumper(LoadFile("modules.yml"))'
+# ysh [-MSome::YAML::Module] < modules.yml
 
 Task::Kensho::Async:
     stopwords: Async
@@ -80,18 +82,32 @@ Task::Kensho::Exceptions:
 Task::Kensho::Hackery:
     stopwords: whippitupitude Hackery
     description: Script Hackery
-    long_description: 'These packages are included less for production work and more for whippitupitude. They reflect packages that people have found incredibly useful for prototyping and debugging before reducing down to a production script.'
+    long_description: >-
+      These packages are included less for production work and more for
+      whippitupitude. They reflect packages that people have found incredibly
+      useful for prototyping and debugging before reducing down to a production
+      script.
     components:
         Smart::Comments: Comments that do more than just sit there
         Term::ProgressBar::Simple: Simple progress bars
-        IO::All: 'IO::All combines all of the best Perl IO modules into a single nifty object oriented interface to greatly simplify your everyday Perl IO idioms.'
+        IO::All: >-
+          IO::All combines all of the best Perl IO modules into a single nifty
+          object oriented interface to greatly simplify your everyday Perl IO
+          idioms.
 
 Task::Kensho::Logging:
     description: Logging
     components:
-        Log::Dispatch: 'This module manages a set of Log::Dispatch::* output objects that can be logged to via a unified interface.'
-        Log::Log4perl: 'Log::Log4perl lets you remote-control and fine-tune the logging behaviour of your system from the outside. It implements the widely popular (Java-based) Log4j logging package in pure Perl.'
-        Log::Contextual: 'Log::Contextual is a simple interface to extensible logging.  It is bundled with a really basic logger, Log::Contextual::SimpleLogger.'
+        Log::Dispatch: >-
+          This module manages a set of Log::Dispatch::* output objects that can
+          be logged to via a unified interface.
+        Log::Log4perl: >-
+          Log::Log4perl lets you remote-control and fine-tune the logging
+          behaviour of your system from the outside. It implements the widely
+          popular (Java-based) Log4j logging package in pure Perl.
+        Log::Contextual: >-
+          Log::Contextual is a simple interface to extensible logging.  It is
+          bundled with a really basic logger, Log::Contextual::SimpleLogger.
         Log::Any: 'Bringing loggers and listeners together.'
 
 


### PR DESCRIPTION
All well known YAML modules support block scalars.

Also add `ysh` (YAML::Shell) to description how to parse.

